### PR TITLE
app.js optimisations.

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -15,11 +15,11 @@ $(document).ready(function() {
 	
 	tabs.each(function(i) {
 		//Get all tabs
-		var tab = $(this).children('li').children('a');
+		var tab = $(this).find('a');
 		tab.click(function(e) {
 			
 			//Get Location of tab's content
-			var contentLocation = $(this).attr("href") + "Tab";
+			var contentLocation = this.href + "Tab";
 			
 			//Let go if not a hashed one
 			if(contentLocation.charAt(0)=="#") {
@@ -31,8 +31,7 @@ $(document).ready(function() {
 				$(this).addClass('active');
 				
 				//Show Tab Content
-				$(contentLocation).parent('.tabs-content').children('li').hide();
-				$(contentLocation).show();
+				$(contentLocation).show().siblings().hide();
 				
 			} 
 		});


### PR DESCRIPTION
I change `var tab = $(this).children('li').children('a');` to `var tab = $(this).find('a');` considering the `ul.tabs` elements has only `a`s in `li`s (`var tab = $(this).find('> li > a');` is pretty much the same as yours, but twice as fast, and `find('a')` forth http://jsperf.com/multiple-children-vs-find).
