### PR TITLE
Fix for improper font antialiasing in WebKit browsers

### DIFF
--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -55,7 +55,7 @@
 		background: #fff;
 		font: 14px/21px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
 		color: #444; 
-		-webkit-font-smoothing: antialiased; /* Fix for webkit rendering */
+		-webkit-font-smoothing: subpixel-antialiased; /* Force webkit to use sub-pixel antialiasing */
 		-webkit-text-size-adjust: none;
  }
 	


### PR DESCRIPTION
I noticed that right now Skeleton is using `-webkit-font-smoothing: antialiased;` in its `base.css` instead of the far better looking `-webkit-font-smoothing: subpixel-antialiased;` that is standard. Most systems use sub-pixel antialiasing by default and for good reasons; it looks much better compared to standard per-pixel methods as you can see here:

![A comparison of font rendering techniques](http://f.cl.ly/items/1l2E1Q0k1O1X3k3v470Z/Sub-pixel%20Anti%20Aliased.png)

I've made the pretty simple change myself in the hopes that this gets through quicker. 

Love the framework by the way, I'm using it with my new personal site (not yet finished)
