### PR TITLE
Add active class to the currently active tab-content.

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -12,8 +12,7 @@ $(document).ready(function() {
 
 	/* Tabs Activiation
 	================================================== */
-	var tabs = $('ul.tabs'),
-	    tabsContent = $('ul.tabs-content');
+	var tabs = $('ul.tabs');
 	
 	tabs.each(function(i) {
 		//Get all tabs
@@ -32,8 +31,8 @@ $(document).ready(function() {
 				tab.removeClass('active');
 				$(this).addClass('active');
 				
-				//Show Tab Content
-				$(contentLocation).show().siblings().hide();
+				//Show Tab Content & add active class
+				$(contentLocation).show().addClass('active').siblings().hide().removeClass('active');
 				
 			} 
 		});


### PR DESCRIPTION
If this is not done, then the active class remains on the tab that was initially visible on page load - even if this tab is now hidden and no longer active. This is confusing when trying to target CSS as a the selector "ul.tabs-content > li.active" , may not be visible.

Also removed unused tabsContent variable.
