### PR TITLE
Fixes for zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 	
 	<!-- Mobile Specific Metas
   ================================================== -->
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" /> 
+	<meta name="viewport" content="width=device-width, initial-scale=1" /> 
 	
 	<!-- CSS
   ================================================== -->

--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -9,6 +9,22 @@
 	
 
 $(document).ready(function() {
+	
+	/* 	Prevent iPhone and iPad to autoscale the page when rotated 
+		(http://adactio.com/journal/4470/)
+	================================================================ */
+
+  	if (navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i)) {
+   	  var viewportmeta = document.querySelector('meta[name="viewport"]');
+   	  if (viewportmeta) {
+   	    viewportmeta.content = 'width=device-width, minimum-scale=1.0, maximum-scale=1.0';
+   	    document.body.addEventListener('gesturestart', function() {
+   	      viewportmeta.content = 'width=device-width, minimum-scale=0.25, maximum-scale=1.6';
+   	    }, false);
+   	  }
+   	}
+
+
 
 	/* Tabs Activiation
 	================================================== */

--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -56,7 +56,7 @@
 		font: 14px/21px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
 		color: #444; 
 		-webkit-font-smoothing: antialiased; /* Fix for webkit rendering */
-		-webkit-text-size-adjust: none;
+		-webkit-text-size-adjust: 100%;
  }
 	
 


### PR DESCRIPTION
Hi,

great work on Skeleton – it's always fun to peek around and see how other people are solving things.

However, I noticed that zoom is disabled on mobile devices due to `maximum-scale=1.0` in the viewport meta tag. I don't think that's very nice to do to mobile visitors, so I removed that. You generally use that declaration when you want to prevent the iOS bug where the whole site zooms when the screen orientation is changed, but that's actually easily fixed with some Javascript (which I also added to `app.js` (see http://adactio.com/journal/4470/).

Also changed `-webkit-text-size-adjust` from `none` to `100%`. `None` prevents Webkit browsers from zooming the text (see http://www.456bereastreet.com/archive/201011/beware_of_-webkit-text-size-adjustnone/)

Give it a spin on a physical device and merge if you want to. Thanks in advance.
