### PR TITLE
Fixed doctype capitalization, removed self-closing tags, modified tabs to avoid accessibility issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!--[if lt IE 7 ]><html class="ie ie6" lang="en"> <![endif]-->
 <!--[if IE 7 ]><html class="ie ie7" lang="en"> <![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"> <![endif]-->
@@ -7,7 +7,7 @@
 
 	<!-- Basic Page Needs
   ================================================== -->
-	<meta charset="utf-8" />
+	<meta charset="utf-8">
 	<title>Your Page Title Here :)</title>
 	<meta name="description" content="">
 	<meta name="author" content="">
@@ -17,20 +17,20 @@
 	
 	<!-- Mobile Specific Metas
   ================================================== -->
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" /> 
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" > 
 	
 	<!-- CSS
   ================================================== -->
-	<link rel="stylesheet" href="stylesheets/base.css" />
-	<link rel="stylesheet" href="stylesheets/skeleton.css" />
-	<link rel="stylesheet" href="stylesheets/layout.css" />
+	<link rel="stylesheet" href="stylesheets/base.css">
+	<link rel="stylesheet" href="stylesheets/skeleton.css">
+	<link rel="stylesheet" href="stylesheets/layout.css">
 	
 	<!-- Favicons
 	================================================== -->
-	<link rel="shortcut icon" href="images/favicon.ico" />
-	<link rel="apple-touch-icon" href="images/apple-touch-icon.png" />
-	<link rel="apple-touch-icon" sizes="72x72" href="images/apple-touch-icon-72x72.png" />
-	<link rel="apple-touch-icon" sizes="114x114" href="images/apple-touch-icon-114x114.png" />
+	<link rel="shortcut icon" href="images/favicon.ico">
+	<link rel="apple-touch-icon" href="images/apple-touch-icon.png">
+	<link rel="apple-touch-icon" sizes="72x72" href="images/apple-touch-icon-72x72.png">
+	<link rel="apple-touch-icon" sizes="114x114" href="images/apple-touch-icon-114x114.png">
 	
 </head>
 <body>

--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -15,13 +15,24 @@ $(document).ready(function() {
 	================================================== */
 	var tabs = $('ul.tabs');
 	
+	/* hide tab content. Doing this with JS
+     makes the tabs work when JS is enabled but
+     CSS is not, an interesting accessibility
+     edge case. Ensures that "active" is respected.
+  */
+  $("ul.tabs-content > li").each(function(t){
+    if(!$(this).hasClass("active")){
+       $(this).hide();
+    };
+  });
+	
 	tabs.each(function(i) {
 		//Get all tabs
 		var tab = $(this).find('> li > a');
 		tab.click(function(e) {
 			
 			//Get Location of tab's content
-			var contentLocation = $(this).attr('href') + "Tab";
+			var contentLocation = $(this).attr('href');
 			
 			//Let go if not a hashed one
 			if(contentLocation.charAt(0)=="#") {

--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -254,7 +254,6 @@
 		border-top-right-radius: 2px; }
 	
 	ul.tabs-content { margin: 0; display: block; }
-	ul.tabs-content > li { display:none; }
 	ul.tabs-content > li.active { display: block; }
 		
 	/* Clearfixing tabs for beautiful stacking */


### PR DESCRIPTION
Per the HTML5 spec, (and since you're using that doctype) self-closing tags like meta and link shouldn't need self-closing tags, so this commit removes them. It also fixes the casing of 'doctype'.

In addition, there's a commit that alters the tab behavior so it works with JS disabled. It unfortunately breaks compatibility with older markup because I removed the Tab prefix. That way link-jumping works when JS is turned off.
