### PR TITLE
Issue #36: Changed tab handling from binding a click handler on each tab to a <body>

### DIFF
--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -13,30 +13,24 @@ $(document).ready(function() {
 	/* Tabs Activiation
 	================================================== */
 
-	var tabs = $('ul.tabs');
+	$('body').delegate('ul.tabs > li > a', 'click', function(e) {
 
-	tabs.each(function(i) {
+		//Get Location of tab's content
+		var contentLocation = $(this).attr('href');
 
-		//Get all tabs
-		var tab = $(this).find('> li > a');
-		tab.click(function(e) {
+		//Let go if not a hashed one
+		if(contentLocation.charAt(0)=="#") {
 
-			//Get Location of tab's content
-			var contentLocation = $(this).attr('href');
+			e.preventDefault();
 
-			//Let go if not a hashed one
-			if(contentLocation.charAt(0)=="#") {
+			//Make Tab Active
+			$(this).parent().siblings().children('a').removeClass('active');
+			$(this).addClass('active');
 
-				e.preventDefault();
+			//Show Tab Content & add active class
+			$(contentLocation).show().addClass('active')
+			    .siblings().hide().removeClass('active');
 
-				//Make Tab Active
-				tab.removeClass('active');
-				$(this).addClass('active');
-
-				//Show Tab Content & add active class
-				$(contentLocation).show().addClass('active').siblings().hide().removeClass('active');
-
-			}
-		});
+	    }
 	});
 });


### PR DESCRIPTION
As the title said, I implemented and tested the new tabs.js code (in Chrome and Firefox only). Turns out, the only difference between what I posted in the issue and actual working code was the 'eventType' parameter. I assume you have a more extensive testing setup for mobile and cross browser compatibility, so I'm leaving that to you. If you need me to do that, I'll do what I can.

As for the benefits, [this blog post](http://www.alfajango.com/blog/the-difference-between-jquerys-bind-live-and-delegate/) covers most of the important issues. Using .bind is slow on load (against the goals of Skeleton), does not apply to future tabs, and consumes more memory than binding a single handler to an ancestor element (in this case, the body element).

Let me know if there's any more you need done for this pull request. Skeleton rocks!
