### PR TITLE
Make tabs work without JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,25 @@
 			<h3>Docs &amp; Support</h3>
 			<p>The easiest way to really get started with Skeleton is to check out the full docs and info at <a href="http://www.getskeleton.com">www.getskeleton.com.</a>. Skeleton is also open-source and has a <a href="https://github.com/dhgamache/skeleton">project on git</a>, so check that out if you want to report bugs or create a pull request. If you have any questions, thoughts, concerns or feedback, please don't hesitate to email me at <a href="mailto:hi@getskeleton.com">hi@getskeleton.com</a>.</p>
 		</div>
+		
+	 <div class="sixteen columns">
+	   <h3>Support for simple tabs</h3>
+	   <!-- Standard <ul> with class of "tabs" -->
+     <ul class="tabs">
+       <li><a class="active" href="#simple">Simple</a></li>
+       <li><a href="#lightweight">Lightweight</a></li>
+       <li><a href="#mobileFriendly">Mobile</a></li>
+       <li><a href="#accessible">Accessible</a></li>
+     </ul>
+
+     <ul class="tabs-content">
+       <!-- Give ID that matches HREF of above anchors -->
+       <li class="active" id="simple">The tabs are clean and simple unordered-list markup and basic CSS</li>
+       <li id="lightweight">The tabs are cross-browser, but don't need a ton of hacky CSS or markup.</li>
+       <li id="mobileFriendly">The tabs work like a charm even on mobile devices.</li>
+       <li id="accessible">The content of the tabs is still visible even when JavaScript is disabbled.</li>
+     </ul>
+	 </div>
 
 	</div><!-- container -->
 

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -12,9 +12,12 @@ $(document).ready(function() {
 
 	/* Tabs Activiation
 	================================================== */
+  // Use CSS to hide the tabs
+  $("ul.tabs-content > li").css("display", "none");
+  $("ul.tabs-content > li.active").css("display", "block");
 
 	var tabs = $('ul.tabs');
-
+  
 	tabs.each(function(i) {
 
 		//Get all tabs

--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -254,7 +254,6 @@
 		border-top-right-radius: 2px; }
 
 	ul.tabs-content { margin: 0; display: block; }
-	ul.tabs-content > li { display:none; }
 	ul.tabs-content > li.active { display: block; }
 
 	/* Clearfixing tabs for beautiful stacking */


### PR DESCRIPTION
I submitted something similar to this a while ago but I did it differently this time - a minor change to the JS that simply takes the display:none out of the CSS and applies it to the tabs using jQuery. This way no page elements are hidden from view when the user has disabled JavaScript, but all functionality remains when JS is there.
