### PR TITLE
Rework of tab.js to generate aria attributes

### DIFF
--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -48,6 +48,13 @@
     		$(this).attr('role', 'tab');
         });
 
+        // if there isn't already a selected tab, make the first one selected
+
+        if($(tabList).find('[aria-selected="true"]').length == 0)
+        {
+        	$(tabs).first().attr('aria-selected', 'true'); 	
+        }
+
         $(tabPanels).each(function(index) {
 
         	var id = $(this).attr('id');
@@ -60,14 +67,13 @@
     		$(this).attr('aria-labeledby', $(tabs[index]).attr('id'));
     		$(tabs[index]).attr('aria-controls', $(this).attr('id'));
 
-        });
+			if($(tabs[index]).attr('aria-selected') == 'true'){
+				$(this).attr('aria-hidden', 'false');	
+			}else{
+				$(this).attr('aria-hidden', 'true');
+			}    		
 
-        // if there isn't already a selected tab, make the first one selected
-
-        if($(tabList).find('[aria-selected="true"]').length == 0)
-        {
-        	$(tabs).first().attr('aria-selected', 'true'); 	
-        }
+        });        
         
     };
 

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -12,7 +12,7 @@
     
     var pluginName = 'skeletonTabs',
         defaults = {
-            propertyName: "value"
+            activeClass: "active"
         };
 
     function Plugin( element, options ) {
@@ -77,10 +77,10 @@
         
         $(tabs).click(function() {
         	var controls = $(this).attr('aria-controls');
-			$(this).siblings().attr('aria-selected', 'false');
-			$(this).attr('aria-selected', 'true');
-			$(tabPanels).attr('aria-hidden', 'true');
-			$(tabPanels).filter('#' + controls).attr('aria-hidden', 'false');
+			$(this).siblings().attr('aria-selected', 'false').removeClass(this.options.activeClass);
+			$(this).attr('aria-selected', 'true').addClass(this.options.activeClass);
+			$(tabPanels).attr('aria-hidden', 'true').css('display', 'none').removeClass(this.options.activeClass);
+			$(tabPanels).filter('#' + controls).attr('aria-hidden', 'false').css('display', 'block').addClass(this.options.activeClass);
 		});        
         
     };

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -46,7 +46,6 @@
     		}
 
     		$(this).attr('role', 'tab');
-
         });
 
         $(tabPanels).each(function(index) {
@@ -58,6 +57,8 @@
     		}
 
     		$(this).attr('role', 'tabpanel');
+    		$(this).attr('aria-labeledby', $(tabs[index]).attr('id'));
+    		$(tabs[index]).attr('aria-controls', $(this).attr('id'));
 
         });
 

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -73,7 +73,15 @@
 				$(this).attr('aria-hidden', 'true');
 			}    		
 
-        });        
+        });
+        
+        $(tabs).click(function() {
+        	var controls = $(this).attr('aria-controls');
+			$(this).siblings().attr('aria-selected', 'false');
+			$(this).attr('aria-selected', 'true');
+			$(tabPanels).attr('aria-hidden', 'true');
+			$(tabPanels).filter('#' + controls).attr('aria-hidden', 'false');
+		});        
         
     };
 

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -55,6 +55,8 @@
         	$(tabs).first().attr('aria-selected', 'true'); 	
         }
 
+        var activeClass = this.options.activeClass;
+
         $(tabPanels).each(function(index) {
 
         	var id = $(this).attr('id');
@@ -68,14 +70,12 @@
     		$(tabs[index]).attr('aria-controls', $(this).attr('id'));
 
 			if($(tabs[index]).attr('aria-selected') == 'true'){
-				$(this).attr('aria-hidden', 'false');	
+				$(this).attr('aria-hidden', 'false').css('display', 'block').addClass(activeClass);	
 			}else{
-				$(this).attr('aria-hidden', 'true');
+				$(this).attr('aria-hidden', 'true').css('display', 'none');
 			}    		
 
-        });
-
-        var activeClass = this.options.activeClass;
+        });        
         
         $(tabs).click(function() {
         	var controls = $(this).attr('aria-controls');

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -8,35 +8,33 @@
 */
 
 
-$(document).ready(function() {
+;(function ( $, window, document, undefined ) {
+    
+    var pluginName = 'skeletonTabs',
+        defaults = {
+            propertyName: "value"
+        };
 
-	/* Tabs Activiation
-	================================================== */
+    function Plugin( element, options ) {
+        this.element = element;
+        this.options = $.extend( {}, defaults, options) ;
+ 
+        this._defaults = defaults;
+        this._name = pluginName;
+        
+        this.init();
+    }
 
-	var tabs = $('ul.tabs');
+    Plugin.prototype.init = function () {
 
-	tabs.each(function(i) {
+    };
 
-		//Get all tabs
-		var tab = $(this).find('> li > a');
-		tab.click(function(e) {
+    $.fn[pluginName] = function ( options ) {
+        return this.each(function () {
+            if (!$.data(this, 'plugin_' + pluginName)) {
+                $.data(this, 'plugin_' + pluginName, new Plugin( this, options ));
+            }
+        });
+    }
 
-			//Get Location of tab's content
-			var contentLocation = $(this).attr('href');
-
-			//Let go if not a hashed one
-			if(contentLocation.charAt(0)=="#") {
-
-				e.preventDefault();
-
-				//Make Tab Active
-				tab.removeClass('active');
-				$(this).addClass('active');
-
-				//Show Tab Content & add active class
-				$(contentLocation).show().addClass('active').siblings().hide().removeClass('active');
-
-			}
-		});
-	});
-});
+})(jQuery, window, document);

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -74,13 +74,15 @@
 			}    		
 
         });
+
+        var activeClass = this.options.activeClass;
         
         $(tabs).click(function() {
         	var controls = $(this).attr('aria-controls');
-			$(this).siblings().attr('aria-selected', 'false').removeClass(this.options.activeClass);
-			$(this).attr('aria-selected', 'true').addClass(this.options.activeClass);
-			$(tabPanels).attr('aria-hidden', 'true').css('display', 'none').removeClass(this.options.activeClass);
-			$(tabPanels).filter('#' + controls).attr('aria-hidden', 'false').css('display', 'block').addClass(this.options.activeClass);
+			$(this).siblings().attr('aria-selected', 'false').removeClass(activeClass);
+			$(this).attr('aria-selected', 'true').addClass(activeClass);
+			$(tabPanels).attr('aria-hidden', 'true').css('display', 'none').removeClass(activeClass);
+			$(tabPanels).filter('#' + controls).attr('aria-hidden', 'false').css('display', 'block').addClass(activeClass);
 		});        
         
     };

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -41,11 +41,23 @@
     			$(this).attr('aria-selected', 'false');	
     		}
 
-    		// add IDs to tabs
-
     		if(!id){
     			$(this).attr('id', 'tab' + parseInt(index + 1));	
     		}
+
+    		$(this).attr('role', 'tab');
+
+        });
+
+        $(tabPanels).each(function(index) {
+
+        	var id = $(this).attr('id');
+
+        	if(!id){
+    			$(this).attr('id', 'tabpanel' + parseInt(index + 1));	
+    		}
+
+    		$(this).attr('role', 'tabpanel');
 
         });
 
@@ -55,18 +67,6 @@
         {
         	$(tabs).first().attr('aria-selected', 'true'); 	
         }
-
-        // add IDs to tab panels
-
-        $(tabPanels).each(function(index) {
-
-        	var id = $(this).attr('id');
-
-        	if(!id){
-    			$(this).attr('id', 'tabpanel' + parseInt(index + 1));	
-    		}
-    		
-        });
         
     };
 

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -26,7 +26,41 @@
     }
 
     Plugin.prototype.init = function () {
+    	var tabList = $(this.element).find('> ul');
+    	var tabs = $(tabList).find('li');
+    	var tabPanels = $(this.element).children().not('ul');
 
+    	tabList.attr('role', 'tablist');
+
+    	$(tabs).each(function(index) {
+
+    		// if there is no aria selected role present, set it to false
+
+    		var selectedVar = $(this).attr('aria-selected');
+
+    		if(!selectedVar){
+    			$(this).attr('aria-selected', 'false');	
+    		}
+
+    		// add IDs to tabs
+
+    		$(this).attr('id', 'tab' + index + 1);
+
+        });
+
+        // if there isn't already a selected tab, make the first one selected
+
+        if($(tabList).find('[aria-selected="true"]').length == 0)
+        {
+        	$(tabs).first().attr('aria-selected', 'true'); 	
+        }
+
+        // add IDs to tab panels
+
+        $(tabPanels).each(function(index) {
+        	$(this).attr('id', 'tabpanel' + index + 1);
+        });
+        
     };
 
     $.fn[pluginName] = function ( options ) {

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -34,17 +34,18 @@
 
     	$(tabs).each(function(index) {
 
-    		// if there is no aria selected role present, set it to false
+    		var ariaSelected = $(this).attr('aria-selected');
+    		var id = $(this).attr('id');
 
-    		var selectedVar = $(this).attr('aria-selected');
-
-    		if(!selectedVar){
+    		if(!ariaSelected){
     			$(this).attr('aria-selected', 'false');	
     		}
 
     		// add IDs to tabs
 
-    		$(this).attr('id', 'tab' + index + 1);
+    		if(!id){
+    			$(this).attr('id', 'tab' + parseInt(index + 1));	
+    		}
 
         });
 
@@ -58,7 +59,13 @@
         // add IDs to tab panels
 
         $(tabPanels).each(function(index) {
-        	$(this).attr('id', 'tabpanel' + index + 1);
+
+        	var id = $(this).attr('id');
+
+        	if(!id){
+    			$(this).attr('id', 'tabpanel' + parseInt(index + 1));	
+    		}
+    		
         });
         
     };

--- a/javascripts/tests/runner.html
+++ b/javascripts/tests/runner.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="http://code.jquery.com/qunit/git/qunit.css" type="text/css" media="screen" />
+    </head>
+    <body>
+        <h1 id="qunit-header">Table Tests</h1>
+        <h2 id="qunit-banner"></h2>
+        <div id="qunit-testrunner-toolbar"></div>
+        <h2 id="qunit-userAgent"></h2>
+        <ol id="qunit-tests"></ol>
+        <div id="qunit-fixture">test markup, will be hidden</div>
+    </body>
+    <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script type="text/javascript" src="http://code.jquery.com/qunit/git/qunit.js"></script>
+    <script type="text/javascript" src="../tabs.js"></script>
+    <script type="text/javascript" src="tests.js"></script>
+</html>

--- a/javascripts/tests/runner.html
+++ b/javascripts/tests/runner.html
@@ -9,7 +9,18 @@
         <div id="qunit-testrunner-toolbar"></div>
         <h2 id="qunit-userAgent"></h2>
         <ol id="qunit-tests"></ol>
-        <div id="qunit-fixture">test markup, will be hidden</div>
+        <div id="qunit-fixture">
+            <div role="tabpanel">
+                <ul>
+                    <li>Simple</li>
+                    <li>Lightweight</li>
+                    <li>Mobile</li>
+                </ul>
+                <div>The tabs are clean and simple divs and basic CSS.</div>
+                <div>The tabs are cross-browser, but don't need a ton of hacky CSS or markup.</div>
+                <div>The tabs work like a charm even on mobile devices.</div>
+            </div>
+        </div>
     </body>
     <script src="http://code.jquery.com/jquery-latest.js"></script>
     <script type="text/javascript" src="http://code.jquery.com/qunit/git/qunit.js"></script>

--- a/javascripts/tests/runner.html
+++ b/javascripts/tests/runner.html
@@ -4,13 +4,13 @@
         <link rel="stylesheet" href="http://code.jquery.com/qunit/git/qunit.css" type="text/css" media="screen" />
     </head>
     <body>
-        <h1 id="qunit-header">Table Tests</h1>
+        <h1 id="qunit-header">SkeletonTab Tests</h1>
         <h2 id="qunit-banner"></h2>
         <div id="qunit-testrunner-toolbar"></div>
         <h2 id="qunit-userAgent"></h2>
         <ol id="qunit-tests"></ol>
         <div id="qunit-fixture">
-            <div role="tabpanel">
+            <div id="tab-container">
                 <ul>
                     <li>Simple</li>
                     <li>Lightweight</li>

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -196,7 +196,7 @@ $(document).ready(function () {
             if(index != 1){
                 equals($(this).attr('aria-selected'),
                 'false',
-                'Expect tab at position ' + index + ' to have aria-selected set to false after clicking tab at position 1');   
+                'Expect tab at position ' + index + ' to have aria-selected set to false after clicking tab at position 1');                 
             }else{
                 equals($(this).attr('aria-selected'),
                 'true',
@@ -208,11 +208,18 @@ $(document).ready(function () {
             if(index != 1){
                 equals($(this).attr('aria-hidden'),
                 'true',
-                'Expect tabpanel at position ' + index + ' to have aria-hidden set to true after clicking tab at position 1');   
+                'Expect tabpanel at position ' + index + ' to have aria-hidden set to true after clicking tab at position 1');
+                
+                ok($(this).is(':hidden'),
+                'Expect tabpanel at position ' + index + ' to be hidden');
+                   
             }else{
                 equals($(this).attr('aria-hidden'),
                 'false',
-                'Expect tabpanel at position ' + index + ' to have aria-hidden set to true since we clicked its tab');   
+                'Expect tabpanel at position ' + index + ' to have aria-hidden set to true since we clicked its tab');
+                
+                ok($(this).not(':hidden'),
+                'Expect tabpanel at position ' + index + ' to not be hidden'); 
             }         
         });
 

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -186,6 +186,7 @@ $(document).ready(function () {
         var tabContainer = $('#qunit-fixture #tab-container');
         var tabList = $(tabContainer).find('> ul');
         var tabPanels = $(tabContainer).children().not('ul');
+        var tabs = tabList.find('li');
         tabContainer.skeletonTabs();
         var clickMe = $(tabContainer).find("ul li:nth-child(2)");
 
@@ -203,7 +204,7 @@ $(document).ready(function () {
             }         
         });
 
-        $(tabpanels).each(function(index) {
+        $(tabPanels).each(function(index) {
             if(index != 1){
                 equals($(this).attr('aria-hidden'),
                 'true',

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -1,41 +1,81 @@
 $(document).ready(function () {
 
-            module("Table markup creation");
+    test("Tab list attribute generation", function () {
 
-            var data = {
-                "table": {
-                    "columns": [
-                            {
-                                "name": "firstName",
-                                "displayName": "First Name"
-                            },
-                            {
-                                "name": "lastName",
-                                "displayName": "Last Name"
-                            }
-                        ]
-                }
-            }
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabs = tabList.find('li');
+        tabContainer.skeletonTabs();        
 
-            test("Generate table headers", function () {
+        equal($(tabList).attr('role'),
+            'tablist',
+            'Expect first unordered list to have tabList role');
 
-                $('#qunit-fixture').tablePlugin(data);
+    });  
 
-                var table = $('#qunit-fixture');
-                var thead = table.find("thead tr");
+    test("Tab attribute generation with nothing set", function () {
 
-                equal(thead.find('th').size(),
-                    data.table.columns.length,
-                    "Expect number of generated table headers to match number in model");
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabs = tabList.find('li');
+        tabContainer.skeletonTabs();        
 
-                equal(thead.find('th').first().html(),
-                    data.table.columns[0].displayName,
-                    "Expect inner HTML to be display name");
+        equal($(tabs).first().attr('aria-selected'),
+            'true',
+            'Expect first tab to have aria-selected set to true');
 
-                equal(thead.find('th').first().attr('data-name'),
-                    data.table.columns[0].name,
-                    "Expect data-name attribute to be set to name");
-
-            });
-
+        $(tabs).each(function(index) {
+            if(index != 0){
+                equal($(this).attr('aria-selected'),
+                'false',
+                'Expect subsequent tabs to have aria-selected set to false')    
+            }            
         });
+
+    });
+
+    test("Tab attribute generation with aria selected set by user", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        $(tabContainer).find("ul li:nth-child(2)").attr('aria-selected', 'true'); 
+        var tabList = $(tabContainer).find('> ul');
+        var tabs = tabList.find('li');
+        tabContainer.skeletonTabs();
+
+        equal($(tabList).find(':nth-child(2)').attr('aria-selected'),
+            'true',
+            'Expect 2nd tab aria-selected role to be true');
+
+        equal($(tabList).find('[aria-selected="true"]').length,
+            1,
+            'Expect one aria-selected role to be true');
+
+        $(tabs).each(function(index) {
+                notEqual($(this).attr('aria-selected'),
+                null,
+                'Expect tab at position ' + index + ' to have an aria-selected attribute that is not null')             
+        });
+
+    });
+
+    test("Tabs and tabpanel ID generation", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabs = tabList.find('li');
+        var tabPanels = $(tabContainer).children().not('ul');
+        tabContainer.skeletonTabs();
+
+        $(tabs).each(function(index) {
+                var tabID = $(this).attr('id');
+                ok(tabID, 'Expect tab at position ' + index + ' to have an id');           
+        });
+
+        $(tabPanels).each(function(index) {
+                var tabPanelID = $(this).attr('id');
+                ok(tabPanelID, 'Expect tab panel at position ' + index + ' to have an id');            
+        });
+
+    });
+
+});

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -1,0 +1,41 @@
+$(document).ready(function () {
+
+            module("Table markup creation");
+
+            var data = {
+                "table": {
+                    "columns": [
+                            {
+                                "name": "firstName",
+                                "displayName": "First Name"
+                            },
+                            {
+                                "name": "lastName",
+                                "displayName": "Last Name"
+                            }
+                        ]
+                }
+            }
+
+            test("Generate table headers", function () {
+
+                $('#qunit-fixture').tablePlugin(data);
+
+                var table = $('#qunit-fixture');
+                var thead = table.find("thead tr");
+
+                equal(thead.find('th').size(),
+                    data.table.columns.length,
+                    "Expect number of generated table headers to match number in model");
+
+                equal(thead.find('th').first().html(),
+                    data.table.columns[0].displayName,
+                    "Expect inner HTML to be display name");
+
+                equal(thead.find('th').first().attr('data-name'),
+                    data.table.columns[0].name,
+                    "Expect data-name attribute to be set to name");
+
+            });
+
+        });

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -179,6 +179,42 @@ $(document).ready(function () {
             }         
         });
 
-    });  
+    });
+
+    test("Clicking tab changes panel", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabPanels = $(tabContainer).children().not('ul');
+        tabContainer.skeletonTabs();
+        var clickMe = $(tabContainer).find("ul li:nth-child(2)");
+
+        $(clickMe).click();
+
+        $(tabs).each(function(index) {
+            if(index != 1){
+                equals($(this).attr('aria-selected'),
+                'false',
+                'Expect tab at position ' + index + ' to have aria-selected set to false after clicking tab at position 1');   
+            }else{
+                equals($(this).attr('aria-selected'),
+                'true',
+                'Expect tab at position ' + index + ' to have aria-selected set to true since we clicked it');   
+            }         
+        });
+
+        $(tabpanels).each(function(index) {
+            if(index != 1){
+                equals($(this).attr('aria-hidden'),
+                'true',
+                'Expect tabpanel at position ' + index + ' to have aria-hidden set to true after clicking tab at position 1');   
+            }else{
+                equals($(this).attr('aria-hidden'),
+                'false',
+                'Expect tabpanel at position ' + index + ' to have aria-hidden set to true since we clicked its tab');   
+            }         
+        });
+
+    });
 
 });

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -225,4 +225,27 @@ $(document).ready(function () {
 
     });
 
+    test("Initialization should set display correctly", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabPanels = $(tabContainer).children().not('ul');
+        var tabs = tabList.find('li');
+        tabContainer.skeletonTabs();
+
+        $(tabPanels).each(function(index) {
+            if(index != 0){
+                
+                ok($(this).is(':hidden'),
+                'Expect tabpanel at position ' + index + ' to be hidden');
+                   
+            }else{
+                
+                ok($(this).not(':hidden'),
+                'Expect tabpanel at position ' + index + ' to not be hidden'); 
+            }         
+        });
+
+    });
+
 });

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -158,6 +158,27 @@ $(document).ready(function () {
                 'Expect tab at position ' + index + ' to match panel id at position ' + index);             
         });
 
-    });    
+    });
+    
+    test("Aria-hidden attribute generation on tabpanels", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabPanels = $(tabContainer).children().not('ul');
+        tabContainer.skeletonTabs();
+
+        $(tabPanels).each(function(index) {
+            if(index != 0){
+                equals($(this).attr('aria-hidden'),
+                'true',
+                'Expect tabpanel at position ' + index + ' to have aria-hidden set to true');   
+            }else{
+                equals($(this).attr('aria-hidden'),
+                'false',
+                'Expect tabpanel at position ' + index + ' to have aria-hidden set to false');   
+            }         
+        });
+
+    });  
 
 });

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -78,4 +78,54 @@ $(document).ready(function () {
 
     });
 
+    test("Tabs and tabpanel ID generation with IDs set by user", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        $(tabContainer).find("ul li:nth-child(2)").attr('id', 'something');
+        $(tabContainer).children().not('ul').first().attr('id', 'else'); 
+        var tabList = $(tabContainer).find('> ul');
+        var tabs = tabList.find('li');
+        var tabPanels = $(tabContainer).children().not('ul');
+        tabContainer.skeletonTabs();
+
+        equal($(tabList).find(':nth-child(2)').attr('id'),
+            'something',
+            'Expect 2nd tab id role to be "something"');
+
+        equal($(tabPanels).first().attr('id'),
+            'else',
+            'Expect 2nd tab id role to be "else"');
+
+    });
+
+    test("Tab role generation", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabs = tabList.find('li');
+        tabContainer.skeletonTabs();
+
+        $(tabs).each(function(index) {
+            equals($(this).attr('role'),
+                'tab',
+                'Expect tab at position ' + index + ' to have an id');             
+        });
+
+    });
+
+    test("Tabpanel role generation", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabPanels = $(tabContainer).children().not('ul');
+        tabContainer.skeletonTabs();
+
+        $(tabPanels).each(function(index) {
+            equals($(this).attr('role'),
+                'tabpanel',
+                'Expect tab panel at position ' + index + ' to have an id');             
+        });
+
+    });
+
 });

--- a/javascripts/tests/tests.js
+++ b/javascripts/tests/tests.js
@@ -128,4 +128,36 @@ $(document).ready(function () {
 
     });
 
+    test("Aria-controls attribute generation", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabPanels = $(tabContainer).children().not('ul');
+        var tabs = tabList.find('li');
+        tabContainer.skeletonTabs();
+
+        $(tabs).each(function(index) {
+            equals($(this).attr('aria-controls'),
+                $(tabPanels[index]).attr('id'),
+                'Expect tab at position ' + index + ' to match panel id at position ' + index);             
+        });
+
+    });
+
+    test("Aria-labeledby attribute generation", function () {
+
+        var tabContainer = $('#qunit-fixture #tab-container');
+        var tabList = $(tabContainer).find('> ul');
+        var tabPanels = $(tabContainer).children().not('ul');
+        var tabs = tabList.find('li');
+        tabContainer.skeletonTabs();
+
+        $(tabPanels).each(function(index) {
+            equals($(this).attr('aria-labeledby'),
+                $(tabs[index]).attr('id'),
+                'Expect tab at position ' + index + ' to match panel id at position ' + index);             
+        });
+
+    });    
+
 });


### PR DESCRIPTION
Hi Dave

I had need to modify the tab plugin included with skeleton to incorporate the aria tab attributes: http://www.w3.org/TR/wai-aria/roles#tab I thought I would go ahead and have them generated by the tab plugin so it would still keep the markup easy for people while providing the accessibility benefits of the aria roles and attributes.

I turned it into an actual jQuery plugin as well. It is backed by 40+ unit tests in QUnit which are included as well. The CSS will need a little work to bring it back in line since I remove the anchor tags.

Anyway just thought I'd share and see if you wanted it. Great work on Skeleton!

-Graham
