### PR TITLE
Changed .delegate to .on for future compatibility with jQuery

### DIFF
--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -8,7 +8,7 @@
 */
 
 
-$('body').delegate('ul.tabs > li > a', 'click', function(e) {
+$('body').on('click', 'ul.tabs > li > a', function(e) {
 
     //Get Location of tab's content
     var contentLocation = $(this).attr('href');


### PR DESCRIPTION
As requested in #36, a quick cosmetic/future-resilient change from `.delegate` to `.on` for tabs.
