### PR TITLE
Styling input type=tel elements

### DIFF
--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -290,6 +290,7 @@
 	input[type="text"],
 	input[type="password"],
 	input[type="email"],
+	input[type="tel"],
 	textarea,
 	select {
 		border: 1px solid #ccc;
@@ -311,6 +312,7 @@
 	input[type="text"]:focus,
 	input[type="password"]:focus,
 	input[type="email"]:focus,
+	input[type="tel"]:focus,
 	textarea:focus {
 		border: 1px solid #aaa;
  		color: #444;

--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -291,6 +291,9 @@
 	input[type="password"],
 	input[type="email"],
 	input[type="tel"],
+	input[type="url"],
+	input[type="number"],
+	input[type="search"],
 	textarea,
 	select {
 		border: 1px solid #ccc;
@@ -313,6 +316,9 @@
 	input[type="password"]:focus,
 	input[type="email"]:focus,
 	input[type="tel"]:focus,
+	input[type="url"]:focus,
+	input[type="number"]:focus,
+	input[type="search"]:focus,
 	textarea:focus {
 		border: 1px solid #aaa;
  		color: #444;


### PR DESCRIPTION
Hello, sir! 

Thank you for Skeleton. I've really enjoyed using it these past few weeks. Today I noticed that input elements of the type "tel" are not styled the same as text, email, and password input elements. It is likely that the tel type is used much more infrequently, but either Ruby on Rails 3.2, or the form builder library I am using in this project, generated an input[type="tel"] for a field called "phone", which makes good sense ultimately. I thought I'd add in the two lines it would take to get them styled similarly.

Thanks again!
