### PR TITLE
Padding Bug on Offset-by-eight

### DIFF
--- a/stylesheets/skeleton.css
+++ b/stylesheets/skeleton.css
@@ -113,7 +113,7 @@
         .container .offset-by-five                  { padding-left: 240px; }
         .container .offset-by-six                   { padding-left: 288px; }
         .container .offset-by-seven                 { padding-left: 336px; }
-        .container .offset-by-eight                 { padding-left: 348px; }
+        .container .offset-by-eight                 { padding-left: 384px; }
         .container .offset-by-nine                  { padding-left: 432px; }
         .container .offset-by-ten                   { padding-left: 480px; }
         .container .offset-by-eleven                { padding-left: 528px; }


### PR DESCRIPTION
This patch fixes an apparent numerical mistake on the offset-by-eight padding when at 768px page width. It looks like an easily-done mistake when adding on 48px and looking at the commit history appears not to be intentional. I came across this code when converting Skeleton to SASS for my own use.
