### PR TITLE
Tabs refactor

### DIFF
--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -8,21 +8,22 @@
  * 8/17/2011
  */
 
-jQuery(function ($) {
+(function ($) {
   // hash change handler
   function hashchange () {
     var hash = window.location.hash
       , el = $('ul.tabs [href*="' + hash + '"]')
+      , content = $(hash)
 
-    if (el.length) {
-      $(el).closest('.tabs').find('.active').removeClass('active');
-      $(el).addClass('active');
-
-      $(hash).show().addClass('active').siblings().hide().removeClass('active');
+    if (el.length && !el.hasClass('active') && content.length) {
+      el.closest('.tabs').find('.active').removeClass('active');
+      el.addClass('active');
+      content.show().addClass('active').siblings().hide().removeClass('active');
     }
   }
 
   // listen on event and fire right away
   $(window).on('hashchange.skeleton', hashchange);
   hashchange();
-});
+  $(hashchange);
+})(jQuery);

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -9,20 +9,20 @@
  */
 
 jQuery(function ($) {
-  $('body').on('click', 'ul.tabs > li > a', function(e) {
-    //Get Location of tab's content
-    var contentLocation = $(this).attr('href');
+  // hash change handler
+  function hashchange () {
+    var hash = window.location.hash
+      , el = $('ul.tabs [href*="' + hash + '"]')
 
-    //Let go if not a hashed one
-    if(contentLocation.charAt(0)=="#") {
-      e.preventDefault();
+    if (el.length) {
+      $(el).closest('.tabs').find('.active').removeClass('active');
+      $(el).addClass('active');
 
-      //Make Tab Active
-      $(this).parent().siblings().children('a').removeClass('active');
-      $(this).addClass('active');
-
-      //Show Tab Content & add active class
-      $(contentLocation).show().addClass('active').siblings().hide().removeClass('active');
+      $(hash).show().addClass('active').siblings().hide().removeClass('active');
     }
-  });
+  }
+
+  // listen on event and fire right away
+  $(window).on('hashchange.skeleton', hashchange);
+  hashchange();
 });

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -9,21 +9,18 @@
  */
 
 $('body').on('click', 'ul.tabs > li > a', function(e) {
+  //Get Location of tab's content
+  var contentLocation = $(this).attr('href');
 
-    //Get Location of tab's content
-    var contentLocation = $(this).attr('href');
+  //Let go if not a hashed one
+  if(contentLocation.charAt(0)=="#") {
+    e.preventDefault();
 
-    //Let go if not a hashed one
-    if(contentLocation.charAt(0)=="#") {
+    //Make Tab Active
+    $(this).parent().siblings().children('a').removeClass('active');
+    $(this).addClass('active');
 
-        e.preventDefault();
-
-        //Make Tab Active
-        $(this).parent().siblings().children('a').removeClass('active');
-        $(this).addClass('active');
-
-        //Show Tab Content & add active class
-        $(contentLocation).show().addClass('active').siblings().hide().removeClass('active');
-
-    }
+    //Show Tab Content & add active class
+    $(contentLocation).show().addClass('active').siblings().hide().removeClass('active');
+  }
 });

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -7,7 +7,6 @@
 * 8/17/2011
 */
 
-
 $('body').on('click', 'ul.tabs > li > a', function(e) {
 
     //Get Location of tab's content

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -1,11 +1,12 @@
-/*
-* Skeleton V1.1
-* Copyright 2011, Dave Gamache
-* www.getskeleton.com
-* Free to use under the MIT license.
-* http://www.opensource.org/licenses/mit-license.php
-* 8/17/2011
-*/
+
+/**
+ * Skeleton V1.1
+ * Copyright 2011, Dave Gamache
+ * www.getskeleton.com
+ * Free to use under the MIT license.
+ * http://www.opensource.org/licenses/mit-license.php
+ * 8/17/2011
+ */
 
 $('body').on('click', 'ul.tabs > li > a', function(e) {
 

--- a/javascripts/tabs.js
+++ b/javascripts/tabs.js
@@ -8,19 +8,21 @@
  * 8/17/2011
  */
 
-$('body').on('click', 'ul.tabs > li > a', function(e) {
-  //Get Location of tab's content
-  var contentLocation = $(this).attr('href');
+jQuery(function ($) {
+  $('body').on('click', 'ul.tabs > li > a', function(e) {
+    //Get Location of tab's content
+    var contentLocation = $(this).attr('href');
 
-  //Let go if not a hashed one
-  if(contentLocation.charAt(0)=="#") {
-    e.preventDefault();
+    //Let go if not a hashed one
+    if(contentLocation.charAt(0)=="#") {
+      e.preventDefault();
 
-    //Make Tab Active
-    $(this).parent().siblings().children('a').removeClass('active');
-    $(this).addClass('active');
+      //Make Tab Active
+      $(this).parent().siblings().children('a').removeClass('active');
+      $(this).addClass('active');
 
-    //Show Tab Content & add active class
-    $(contentLocation).show().addClass('active').siblings().hide().removeClass('active');
-  }
+      //Show Tab Content & add active class
+      $(contentLocation).show().addClass('active').siblings().hide().removeClass('active');
+    }
+  });
 });


### PR DESCRIPTION
- Style cleanup (I can reverse it if needed)
- Don't assume `$` and leverage `jQuery` instead.
- Works even before DOM is completely ready!
- Switched to `hashchange` listening instead of delegation
  We still check that the given hash exists as a `href` within a valid Skeleton tabs markup, but you can now send links around that focus on tabs.
  As an example, if I tweet out mypage.com/#activetab, it will check that `#activetab` is a valid href in an anchor within an `<ul class="tabs">` element, and if so, make that tab active.
- In addition, you can have multiple anchors in the page that trigger tabs by simply setting the appropriate `href`.
- Leverage `closest` and `find` instead of `parent`, `siblings` and `children` (code simplification).
