### PR TITLE
Added max-width: 100%; to keep cols constrained within parent

### DIFF
--- a/stylesheets/skeleton.css
+++ b/stylesheets/skeleton.css
@@ -23,7 +23,7 @@
 
     .container                                  { position: relative; width: 960px; margin: 0 auto; padding: 0; }
     .container .column,
-    .container .columns                         { float: left; display: inline; margin-left: 10px; margin-right: 10px; }
+    .container .columns                         { float: left; display: inline; margin-left: 10px; margin-right: 10px; max-width: 100%; }
     .row                                        { margin-bottom: 20px; }
 
     /* Nested Column Classes */


### PR DESCRIPTION
For example: this prevents right-aligned text from overlapping the edge of the parent container.

Hello, I was wondering what you thought of doing something like this. I've got a few sites that push content pretty far right in their containers which causes the content to overlap the parent container on smaller screens. (this seems to fix that issue pretty reliably for me)
