### PR TITLE
Don't try to "fix" font smoothing. 

### DIFF
--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -54,7 +54,6 @@
 		background: #fff;
 		font: 14px/21px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
 		color: #444;
-		-webkit-font-smoothing: antialiased; /* Fix for webkit rendering */
 		-webkit-text-size-adjust: 100%;
  }
 


### PR DESCRIPTION
The rule for "-webkit-font-smoothing" was removed, because it doesn't 'fix' anything, but rather looks really, really bad on Chrome. 

See here for more reasons why it should be removed: http://www.usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/ (this article isn't written by me, but it does mention Skeleton)

Screenshot with "-webkit-font-smoothing":

![screenshot](http://i.imgur.com/Jc7C6.png)

Screenshot without "-webkit-font-smoothing":

![screenshot](http://i.imgur.com/rDu64.png)
