### PR TITLE
Removed font "fix" that worsen readability

### DIFF
--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -54,7 +54,6 @@
 		background: #fff;
 		font: 14px/21px "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
 		color: #444;
-		-webkit-font-smoothing: antialiased; /* Fix for webkit rendering */
 		-webkit-text-size-adjust: 100%;
  }
 


### PR DESCRIPTION
`-webkit-font-smoothing: antialiased;` on the entire document is an abuse of the property, it worsens the readability of body text considerably.

Example: http://imgur.com/I12Ff (Chrome/OSX)

Argument: http://www.usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/
