### PR TITLE
Missing license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+All parts of Skeleton are free to use and abuse under the open-source MIT
+license. The full licensing language can be found below.
+
+More importantly, I would love to have a small community of contributors to
+Skeleton, so please feel free to jump over the Skeleton Github page[1] and
+contribute to make Skeleton a better boilerplate for everyone!
+
+[1] https://github.com/dhgamache/Skeleton
+
+
+Copyright (c) 2011-2013 Dave Gamache http://www.davegamache.com/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
Hi, Dave

I am adding your Skeleton to my project, and I while performing due diligence, I have discovered that the Git repository has no express licensing terms attached to it.  Your website states a license, though, so I've added the licensing terms from your website.

Feel free to pull the changes :-)

Kind regards,
Jan

```
Add licensing text from the Skeleton website

There was no license in the repository, but there was one on the
Skeleton's website[1].  Copy and paste the license, incorporate the MIT
license text from the opensource.org website[2].

 [1] http://www.getskeleton.com/#licenseandlog
 [2] http://www.opensource.org/licenses/mit-license.php
```
