### PR TITLE
Add box-sizing to columns

### DIFF
--- a/stylesheets/skeleton.css
+++ b/stylesheets/skeleton.css
@@ -23,7 +23,7 @@
 
     .container                                  { position: relative; width: 960px; margin: 0 auto; padding: 0; }
     .container .column,
-    .container .columns                         { float: left; display: inline; margin-left: 10px; margin-right: 10px; }
+    .container .columns                         { float: left; display: inline; margin-left: 10px; margin-right: 10px; box-sizing: border-box; -webkit-box-sizing: border-box; -moz-box-sizing: border-box; -ms-box-sizing: border-box; -o-box-sizing: border-box; -khtml-box-sizing: border-box; }
     .row                                        { margin-bottom: 20px; }
 
     /* Nested Column Classes */


### PR DESCRIPTION
I think box-sizing: border-box should be added to columns to allow for borders and padding to be applied directly to .column/.columns without breaking the grid.

This should help cut down on the amount of markup required for the grid setup (in some cases).

Original commit message:
_Added box-sizing to columns to allow for borders, padding etc. to be
added inside the column, thus not breaking the grid if required._

See here for current browser compatibility:
http://caniuse.com/#search=box-sizing
