### PR TITLE
Removed color property on <strong> tags.

### DIFF
--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -79,7 +79,7 @@
 	p.lead { font-size: 21px; line-height: 27px; color: #777;  }
 
 	em { font-style: italic; }
-	strong { font-weight: bold; color: #333; }
+	strong { font-weight: bold; }
 	small { font-size: 80%; }
 
 /*	Blockquotes  */


### PR DESCRIPTION
&lt;strong&gt; tags shouldn't assert a certain color. Example:

<a href="#anchor"><strong>This will be black</strong> and this will be blue</a>

I've updated the tag's style to not include any color, thus fitting more with
the "Style Agnostic" principle of Skeleton.
