### PR TITLE
Changed Google Fonts link protocol to HTTPS

### DIFF
--- a/examples/landing/index.html
+++ b/examples/landing/index.html
@@ -15,7 +15,7 @@
 
   <!-- FONT
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link href='http://fonts.googleapis.com/css?family=Raleway:400,300,600' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Raleway:400,300,600' rel='stylesheet' type='text/css'>
 
   <!-- CSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
Wrote it as `//`, which was the syntax used in the jQuery link.
