### PR TITLE
Remove hardcoded height

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -120,7 +120,6 @@
   .navbar-spacer {
     display: block;
     width: 100%;
-    height: 6.5rem;
     background: #fff;
     z-index: 99;
     border-top: 1px solid #eee;
@@ -139,11 +138,12 @@
   .navbar-link {
     text-transform: uppercase;
     font-size: 11px;
+    display:block;
     font-weight: 600;
     letter-spacing: .2rem;
+    padding:2.25rem 0;
     margin-right: 35px;
     text-decoration: none;
-    line-height: 6.3rem;
     color: #222; }
   .navbar-link.active {
     color: #33C3F0; }


### PR DESCRIPTION
This fixes the vertical misalignment for the nav on the demo site - 
![screen shot 2014-12-10 at 7 29 55 am](https://cloud.githubusercontent.com/assets/3824954/5375972/6bc41764-803e-11e4-8bb3-3ffaaff84433.png)
