### PR TITLE
Improve anti-aliasing on WebKit browsers

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -106,6 +106,8 @@ body {
   font-weight: 400;
   font-family: "Raleway", "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #222; }
+body * {
+  -webkit-font-smoothing: antialiased; }
 
 
 /* Typography


### PR DESCRIPTION
`-webkit-font-smoothing` provides WebKit browsers with improved anti-aliasing capabilities. The reason to nest this with the ever-notorious universal identifier (`*`) is that not all HTML elements are caught under the `body` blanket. This is most notable when comparing the way fonts render text inside of `<input[type="button"]>` form elements as opposed to purely textual elements like `<a>`, `<p>`. To deliver a beautiful, consistent experience, we need to apply this universally for all elements on WebKit.
