### PR TITLE
Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "skeleton",
+  "version": "2.0.1",
+  "homepage": "http://getskeleton.com/",
+  "authors": [
+    "Dave Gamache <hello@davegamache.com> (http://davegamache.com/)"
+  ],
+  "description": "Skeleton is a simple, responsive boilerplate to kickstart any responsive project.",
+  "main": "css/skeleton.css",
+  "keywords": [
+    "css",
+    "skeleton",
+    "responsive",
+    "boilerplate"
+  ],
+  "license": "MIT"
+}

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,10 @@
   "name": "skeleton",
   "version": "2.0.1",
   "homepage": "http://getskeleton.com/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dhg/Skeleton"
+  },
   "authors": [
     "Dave Gamache <hello@davegamache.com> (http://davegamache.com/)"
   ],


### PR DESCRIPTION
## Notes
- Helps with #197 (but you'll still have to [register your package](http://bower.io/docs/creating-packages/#register)).
- You might want to change the keywords.
- normalize.css and Raleway are included in `index.html`, but aren't part dependencies of the Bower package. You might want to add `css/normalize.css` to the `main` field or add normalize.css as a dependency if you want people to always use normalize with Skeleton (you'll still need to remind users to include the CSS file though). Also, you might want to add a note that people can get Raleway from Google Fonts.
