### PR TITLE
added example ID to example select input

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,7 +326,7 @@
             </div>
             <div class="six columns">
               <label for="exampleRecipientInput">Reason for contacting</label>
-              <select class="u-full-width">
+              <select class="u-full-width" id="exampleRecipientInput">
                 <option value="Option 1">Questions</option>
                 <option value="Option 2">Admiration</option>
                 <option value="Option 3">Can I get your number?</option>
@@ -355,7 +355,7 @@
     </div>
     <div class="six columns">
       <label for="exampleRecipientInput">Reason for contacting</label>
-      <select class="u-full-width">
+      <select class="u-full-width" id="exampleRecipientInput">
         <option value="Option 1">Questions</option>
         <option value="Option 2">Admiration</option>
         <option value="Option 3">Can I get your number?</option>


### PR DESCRIPTION
Just something I noticed when checking out the example form, a missing ID prevented the label from being useful! :thumbsup:
