### PR TITLE
Added missing CSS rule for number input

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -226,6 +226,7 @@ input[type="button"].button-primary:focus {
 /* Forms
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 input[type="email"],
+input[type="number"],
 input[type="search"],
 input[type="text"],
 input[type="tel"],
@@ -242,6 +243,7 @@ select {
   box-sizing: border-box; }
 /* Removes awkward default styles on some inputs for iOS */
 input[type="email"],
+input[type="number"],
 input[type="search"],
 input[type="text"],
 input[type="tel"],
@@ -256,6 +258,7 @@ textarea {
   padding-top: 6px;
   padding-bottom: 6px; }
 input[type="email"]:focus,
+input[type="number"]:focus,
 input[type="search"]:focus,
 input[type="text"]:focus,
 input[type="tel"]:focus,


### PR DESCRIPTION
`input[type="number"]` styling wasn’t included, which makes for some ugly CSS; text input is so last year. :)
