### PR TITLE
removed duplicate rule

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -353,8 +353,6 @@ ul,
 ol,
 form {
   margin-bottom: 2.5rem; }
-p {
-  margin-top: 0; }
 
 
 /* Utilities


### PR DESCRIPTION
Removed duplicate `p {margin-top: 0}` rule from Spacing section as was already defined in Typography
