### PR TITLE
Rows attribute being ignored on textarea

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -234,13 +234,21 @@ input[type="url"],
 input[type="password"],
 textarea,
 select {
-  height: 38px;
   padding: 6px 10px; /* The 6px vertically centers text on FF, ignored by Webkit */
   background-color: #fff;
   border: 1px solid #D1D1D1;
   border-radius: 4px;
   box-shadow: none;
   box-sizing: border-box; }
+input[type="email"],
+input[type="number"],
+input[type="search"],
+input[type="text"],
+input[type="tel"],
+input[type="url"],
+input[type="password"],
+select {
+  height: 38px; }
 /* Removes awkward default styles on some inputs for iOS */
 input[type="email"],
 input[type="number"],


### PR DESCRIPTION
Specifying height with CSS on a textarea makes it ignore the rows
attribute. Fixed it by moving the height declaration into its own group
of selectors.
