### PR TITLE
Update grid with bootstrap like classes for small and medium devices

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -9,7 +9,7 @@
 
 
 /* Table of contents
-–––––––––––––––––––––––––––––––––––––––––––––––––– 
+––––––––––––––––––––––––––––––––––––––––––––––––––
 - Grid
 - Base Styles
 - Typography
@@ -29,27 +29,26 @@
 /* Grid
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .container {
-  position: relative; 
+  position: relative;
   width: 100%;
-  max-width: 960px; 
-  margin: 0 auto; 
-  padding: 0 15px; 
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 1%;
   box-sizing: border-box; }
-.row { 
-  margin: 0 -15px 2rem; }
-.row .column,        
-.row .columns { 
-  float: left; 
-  width: 100%; 
-  padding-right: 15px;
-  padding-left: 15px;
+.row {
+  margin: 0 -1% 2rem; }
+.row .column,
+.row .columns {
+  float: left;
+  width: 100%;
+  padding: 0 1%;
   box-sizing: border-box; }
 
-/* For devices larger than 550px */
-@media (min-width: 550px) {
+/* For devices larger than 600px */
+@media (min-width: 600px) {
 
-  .container { width: 90%; }
-  
+  .container { width: 96%; }
+
   .row .one.column,
   .row .one.columns          { width: 8.33333333334%; }
   .row .two.columns          { width: 16.6666666667%; }
@@ -62,7 +61,7 @@
   .row .nine.columns         { width: 75.0%;          }
   .row .ten.columns          { width: 83.3333333334%; }
   .row .eleven.columns       { width: 91.6666666667%; }
-  .row .twelve.columns       { width: 100%; margin-left: 0; }
+  .row .twelve.columns       { width: 100%;           }
 
   .row .one-third.column     { width: 33.3333333334%; }
   .row .two-thirds.column    { width: 66.6666666667%; }
@@ -93,10 +92,10 @@
 /* Base Styles
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 /* NOTE
-html is set to 62.5% so that all the REM measurements throughout Skeleton 
+html is set to 62.5% so that all the REM measurements throughout Skeleton
 are based on 10px sizing. So basically 1.5rem = 15px :) */
-html { 
-  font-size: 62.5%; } 
+html {
+  font-size: 62.5%; }
 body {
   font-size: 1.5em; /* currently ems cause chrome bug misinterpreting rems on body element */
   line-height: 1.6;
@@ -107,7 +106,7 @@ body {
 
 /* Typography
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-h1, h2, h3, h4, h5, h6 { 
+h1, h2, h3, h4, h5, h6 {
   font-weight: 300;
   margin-top: 0;
   margin-bottom: 2rem; }
@@ -134,13 +133,13 @@ p {
 
 /* Links
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-a { 
+a {
   color: #1EAEDB; }
-a:hover { 
+a:hover {
   color: #0FA0CE; }
 
 
-/* Buttons 
+/* Buttons
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .button,
 button,
@@ -161,7 +160,7 @@ input[type="button"] {
   line-height: 38px;
   padding: 0 30px;
   letter-spacing: .1rem;
-  text-transform: uppercase; 
+  text-transform: uppercase;
   white-space: nowrap;
   box-sizing: border-box; }
 .button:hover,
@@ -254,18 +253,18 @@ label > .label-body {
 
 /* Lists
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-ul { 
+ul {
   list-style: circle inside; }
-ol { 
+ol {
   list-style: decimal inside; }
 ol, ul {
   margin-top: 0;
   padding-left: 0; }
-ul ul, 
+ul ul,
 ul ol,
-ol ol, 
-ol ul { 
-  margin: 1.5rem 0 1.5rem 3rem; 
+ol ol,
+ol ul {
+  margin: 1.5rem 0 1.5rem 3rem;
   font-size: 90%; }
 li {
   margin-bottom: 1rem; }
@@ -356,7 +355,7 @@ hr {
 /* Self Clearing Goodness */
 .container:after,
 .row:after,
-.u-cf { 
+.u-cf {
   content: "";
   display: table;
   clear: both; }
@@ -365,10 +364,10 @@ hr {
 /* Media Queries
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 /*
-Note: The best way to structure the use of media queries is to create the queries 
+Note: The best way to structure the use of media queries is to create the queries
 near the relevant code. For example, if you wanted to change the styles for buttons
-on small devices, paste the mobile query code up in the buttons section and style it 
-there. 
+on small devices, paste the mobile query code up in the buttons section and style it
+there.
 */
 
 

--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -31,25 +31,40 @@
 .container {
   position: relative;
   width: 100%;
-  max-width: 1280px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 0 1%;
   box-sizing: border-box; }
 .row {
-  margin: 0 -1% 2rem; }
-.row .column,
+  margin: 0 -0.5% 1rem;  }
 .row .columns {
   float: left;
   width: 100%;
-  padding: 0 1%;
-  box-sizing: border-box; }
+  padding:0 0.5%;
+  box-sizing: border-box;
+  margin-bottom: 0;  }
 
-/* For devices larger than 600px */
-@media (min-width: 600px) {
+  /* Small Grid */
+  .row .sm-one.columns,
+  .row .small-one.columns        { width: 25% }
+  .row .sm-two.columns,
+  .row .small-two.columns        { width: 50% }
+  .row .sm-three.columns,
+  .row .small-three.columns      { width: 75% }
+  .row .sm-four.columns,
+  .row .small-four.columns       { width: 100% }
+  
 
-  .container { width: 96%; }
+/* Large Grid */
+@media (min-width: 550px) {
 
-  .row .one.column,
+  .row { margin: 0 -1% .5rem; }
+  .row .columns {
+    padding: 0 1%;
+    margin-bottom: 1.5%;}
+
+  .container { width: 90%; }
+
   .row .one.columns          { width: 8.33333333334%; }
   .row .two.columns          { width: 16.6666666667%; }
   .row .three.columns        { width: 25%;            }
@@ -67,8 +82,43 @@
   .row .two-thirds.column    { width: 66.6666666667%; }
 
   .row .one-half.column      { width: 50%; }
+}
 
-  /* Offsets */
+/* Medium Grid */
+@media (min-width: 550px) and (max-width: 960px){
+  .row { margin: 0 -0.75% .5rem; }
+  .row .columns { padding: 0 0.75%; }
+
+  .container { width: 95%; }
+
+  .row .md-one.columns,
+  .row .medium-one.columns     { width: 12.5% }
+  .row .md-two.columns,
+  .row .medium-two.columns     { width: 25%   }
+  .row .md-three.columns,
+  .row .medium-three.columns   { width: 37.5% }
+  .row .md-four.columns,
+  .row .medium-four.columns    { width: 50%   }
+  .row .md-five.columns,
+  .row .medium-five.columns    { width: 62.5% }
+  .row .md-six.columns,
+  .row .medium-six.columns     { width: 75%   }
+  .row .md-seven.columns,
+  .row .medium-seven.columns   { width: 87.5% }
+  .row .md-eight.columns,
+  .row .medium-eight.columns   { width: 100%  }
+
+  .row .md-full.columns,
+  .row .medium-full.columns    { width: 100%; }
+  .row .md-half.columns,
+  .row .medium-half.columns    { width: 50%;  }
+
+}
+
+/* Offsets */
+@media (min-width: 960px) {
+
+  Offsets
   .row .offset-by-one        { margin-left: 8.33333333334%; }
   .row .offset-by-two        { margin-left: 16.6666666667%; }
   .row .offset-by-three      { margin-left: 25%;            }

--- a/grid-test.html
+++ b/grid-test.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+
+    <meta charset="utf-8">
+    <title>Grid Test</title>
+    <meta name="description" content="Page setup to test the grid system">
+    <meta name="author" content="">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/skeleton.css">
+
+    <style>
+      .demo-col {
+        background-color: #00b7ff;
+        width: 100%;
+        height: 60px;
+      }
+      .demo-col-lg {
+        background-color: #00b7ff;
+        width: 100%;
+        height: 300px;
+      }
+      .demo-col-md {
+        background-color: #00b7ff;
+        width: 100%;
+        height: 200px;
+      }
+    </style>
+
+  </head>
+  <body>
+
+    <div class="container" style="margin-top: 25px;">
+
+      <div class="row">
+        <div class="four columns md-six">
+          <div class="demo-col"></div>
+        </div>
+        <div class="eight columns md-two">
+          <div class="demo-col"></div>
+        </div>
+      </div><!-- end of row -->
+
+      <div class="row">
+        <div class="twelve columns">
+          <div class="demo-col-lg"></div>
+        </div>
+      </div><!-- end of row -->
+
+      <div class="row">
+        <div class="four columns md-four">
+          <div class="demo-col-md"></div>
+        </div>
+        <div class="four columns md-four">
+          <div class="demo-col-md"></div>
+        </div>
+        <div class="four columns md-eight">
+          <div class="demo-col-md"></div>
+        </div>
+      </div><!-- end of row -->
+
+      <div class="row">
+        <div class="six columns">
+          <div class="demo-col-md"></div>
+        </div>
+        <div class="six columns">
+          <div class="demo-col-md"></div>
+        </div>
+      </div><!-- end of row -->
+
+      <div class="row">
+        <div class="six columns offset-by-three md-full">
+          <div class="demo-col"></div>
+        </div>
+      </div><!-- end of row -->
+
+    </div>
+
+  </body>
+</html>


### PR DESCRIPTION
This PR relates to issue [#210](https://github.com/dhg/Skeleton/issues/210). I used the grid that was in this branch as the base, and added two additional grid systems to it one for small/mobile devices and one for medium/tablet devices. The original grid is still there and functions the same. 
