### PR TITLE
Google font import fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
   <!-- FONT
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+  <link href="http://fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
 
   <!-- CSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
Added `http:` to the front of the Google font link for Raleway, so that font is loaded.

Signed-off-by: Ben Hinchley benhinchley@me.com
