### PR TITLE
Match version number for Skeleton on Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All parts of Skeleton are free to use and abuse under the [open-source MIT licen
 
 The following are extensions to Skeleton built by the community. They are not officially supported, but all have been tested and are compatible with v2.0 (exact release noted):
 - [Skeleton on LESS](https://github.com/whatsnewsaes/Skeleton-less): Skeleton built with LESS for easier replacement of grid, color, and media queries. (Last update was to match v2.0.1)
-- [Skeleton on Sass](https://github.com/whatsnewsaes/Skeleton-Sass): Skeleton built with Sass for easier replacement of grid, color, and media queries. (Last update was to match v2.0.1)
+- [Skeleton on Sass](https://github.com/whatsnewsaes/Skeleton-Sass): Skeleton built with Sass for easier replacement of grid, color, and media queries. (Last update was to match v2.0.4)
 
 Have an extension you want to see here? Just shoot an email to hi@getskeleton.com with your extension!
 


### PR DESCRIPTION
Seems like Skeleton on Sass has been updated to v2.0.4. Change README to reflect this.

As a side point, would it be easier to not list the version numbers and ask the user to check if the project is up to date?
