### PR TITLE
adds non-responsive-column class for creating grids that must maintain s...

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -36,10 +36,20 @@
   padding: 0 20px;
   box-sizing: border-box; }
 .column,
-.columns {
+.columns,
+.non-responsive-column {
   width: 100%;
   float: left;
   box-sizing: border-box; }
+
+/* used for grid structures that need to be maintained in mobile */
+.non-responsive-column             { margin-left: 4%;       }
+.non-responsive-column:first-child { margin-left: 0;        }
+
+.one-fourth.non-responsive-column  { width: 22%;            }
+.one-third.non-responsive-column   { width: 30.6666666667%; }
+.two-thirds.non-responsive-column  { width: 65.3333333333%; }
+.one-half.non-responsive-column    { width: 48%;            }
 
 /* For devices larger than 400px */
 @media (min-width: 400px) {


### PR DESCRIPTION
Adds non-responsive-columns which allow grid structures to be maintained in mobile. Check out this gist for a use case [4x4 grid](https://gist.github.com/jonathan-potter/5d44e8009c4a8caa9ceb). The screenshots show how it works too.

I made another attempt that put these rules in with the rest of the grid size rules. It ended up being more lines of code and it was more confusing, so it pitched it and went with this.
![screen shot 2015-03-15 at 1 45 04 pm](https://cloud.githubusercontent.com/assets/3733595/6658047/1bbe9286-cb1a-11e4-8d6c-4e2b49eef322.png)
![screen shot 2015-03-15 at 1 45 18 pm](https://cloud.githubusercontent.com/assets/3733595/6658048/1bc153fe-cb1a-11e4-85cb-c14049d9d484.png)
