### PR TITLE
Updated Versions: Skeleton-less and Skeleton-Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ All parts of Skeleton are free to use and abuse under the [open-source MIT licen
 ## Extensions
 
 The following are extensions to Skeleton built by the community. They are not officially supported, but all have been tested and are compatible with v2.0 (exact release noted):
-- [Skeleton on LESS](https://github.com/whatsnewsaes/Skeleton-less): Skeleton built with LESS for easier replacement of grid, color, and media queries. (Last update was to match v2.0.1)
-- [Skeleton on Sass](https://github.com/whatsnewsaes/Skeleton-Sass): Skeleton built with Sass for easier replacement of grid, color, and media queries. (Last update was to match v2.0.1)
+- [Skeleton on LESS](https://github.com/whatsnewsaes/Skeleton-less): Skeleton built with LESS for easier replacement of grid, color, and media queries. (Last update was to match v2.0.4)
+- [Skeleton on Sass](https://github.com/whatsnewsaes/Skeleton-Sass): Skeleton built with Sass for easier replacement of grid, color, and media queries. (Last update was to match v2.0.4)
 
 Have an extension you want to see here? Just shoot an email to hi@getskeleton.com with your extension!
 


### PR DESCRIPTION
I noticed this small detail was out of date. Both Skeleton-less and Skeleton-Sass said version 2.0.1 here but both have since been updated to 2.0.4.
