### PR TITLE
Set clearfix styles for helper class .u-cf onto the pseudo element :afte...

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -386,7 +386,7 @@ hr {
 /* Self Clearing Goodness */
 .container:after,
 .row:after,
-.u-cf {
+.u-cf:after {
   content: "";
   display: table;
   clear: both; }


### PR DESCRIPTION
For me it looks like a mistake that the `.u-cf` class lacks the `:after` pseudo element.

It caused a layout issue in the project I’m currently working on, because the display value changed from `display: block` to `display: table` due to this helper class. 
