### PR TITLE
Fixes container overflow on pre>code blocks

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -317,7 +317,8 @@ code {
 pre > code {
   display: block;
   padding: 1rem 1.5rem;
-  white-space: pre; }
+  white-space: pre;
+  overflow: scroll}
 
 
 /* Tables


### PR DESCRIPTION
![screen shot 2015-06-26 at 2 24 13 pm](https://cloud.githubusercontent.com/assets/1628239/8387706/b11ae8ac-1c0f-11e5-883b-4dbe9151e14a.png)

Pasted from commit comment: 
I found that without setting overflow explicitly on the nested &lt;code&gt;
 element, any non-wrapping code would create an overflow that would scroll the &lt;pre&gt; element, but would therefor leave the code wrapper behind, with overflowing code appearing outside the wrapper (sample attached). This change fixes the UI so all code stays within the wrapper on scroll. Tested in Chrome, Firefox, and Safari (OS X).
