### PR TITLE
added button type to list of inputs which need ios default styles removed

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -243,6 +243,7 @@ select {
   box-sizing: border-box; }
 /* Removes awkward default styles on some inputs for iOS */
 input[type="button"],
+input[type="submit"],
 input[type="email"],
 input[type="number"],
 input[type="search"],

--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -242,6 +242,7 @@ select {
   box-shadow: none;
   box-sizing: border-box; }
 /* Removes awkward default styles on some inputs for iOS */
+input[type="button"],
 input[type="email"],
 input[type="number"],
 input[type="search"],


### PR DESCRIPTION
We were seeing some funky styling on buttons in iOS 8 on the iPad and tracked it down to the fact that skeleton isn't applying the same `-webkit-appearance: none` fix to button inputs. This PR adds that type to the list.

![image](https://cloud.githubusercontent.com/assets/4907/9092461/5b40378c-3b74-11e5-9882-758b226a08a2.png)
