### PR TITLE
sets the horizontal overflow for code blocks to scroll to prevent code from spilling beyond the margin

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -317,7 +317,8 @@ code {
 pre > code {
   display: block;
   padding: 1rem 1.5rem;
-  white-space: pre; }
+  white-space: pre;
+  overflow-x: scroll; }
 
 
 /* Tables


### PR DESCRIPTION
This is one option for resolving the issue outlined here:
https://github.com/dhg/Skeleton/issues/292

The problem is especially noticeable on smaller screen sizes.
