### PR TITLE
Add a foreground color for text inputs.

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -236,6 +236,7 @@ textarea,
 select {
   height: 38px;
   padding: 6px 10px; /* The 6px vertically centers text on FF, ignored by Webkit */
+  color: #222;
   background-color: #fff;
   border: 1px solid #D1D1D1;
   border-radius: 4px;


### PR DESCRIPTION
Some browser/platform combinations use system colors for inputs as the default. When the system is configured with a high-contrast light-on-dark theme, text inputs with a light background and no specified foreground color become difficult or impossible to read.
