### PR TITLE
Rename .u-* to .util-*

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -359,15 +359,15 @@ form {
 
 /* Utilities
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-.u-full-width {
+.util-full-width {
   width: 100%;
   box-sizing: border-box; }
-.u-max-full-width {
+.util-max-full-width {
   max-width: 100%;
   box-sizing: border-box; }
-.u-pull-right {
+.util-pull-right {
   float: right; }
-.u-pull-left {
+.util-pull-left {
   float: left; }
 
 
@@ -386,7 +386,7 @@ hr {
 /* Self Clearing Goodness */
 .container:after,
 .row:after,
-.u-cf {
+.util-cf {
   content: "";
   display: table;
   clear: both; }


### PR DESCRIPTION
I'm using Skeleton (it's great!) in a project that also deals with microformats2, which specifies that `u-*` classnames are used to indicate url properties of machine readable markup.

The result is that anything marked with, e.g. `.u-full-width` gets picked up as a url property. Details about the microformats2 parsing convention can be found here: http://microformats.org/wiki/microformats2#naming_conventions_for_generic_parsing

Renaming `.u-*` to `.util-*` avoids this issue while potentially making it clearer that these are utility classes that apply inline styles.

Kevin Marks has a great detailed explanation of the issue here: http://www.kevinmarks.com/u-means-style.html