### PR TITLE
Fix Raleway link

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
   <!-- FONT
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
 
   <!-- CSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
This link not including `https://` makes loading the page locally take upwards of 30 seconds as Chrome tries to look for the link locally. This commit fixes this and makes for a much more pleasant experience.