### PR TITLE
Allow responsive Iframes and make sure, Images won't break the layout

### DIFF
--- a/css/skeleton.css
+++ b/css/skeleton.css
@@ -416,3 +416,25 @@ there.
 
 /* Larger than Desktop HD */
 @media (min-width: 1200px) {}
+
+/* Responsive Embeds. Use div class="fluidMedia" and then add embedding code */
+.fluidMedia {
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.fluidMedia iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* make sure, images won't crash the layout */
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
I think, Skeleton is almost perfect. Small, easy to use and everything. But when it comes to use Iframes, you're lost. This non-js-div-solution will allow to use Iframes in a responsive manor. You can even use these fluidMedia-Containers in columns etc.