### PR TITLE
fixed-raleway-link

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
   <!-- FONT
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Raleway:300,400,600&display=swap" rel="stylesheet">
 
   <!-- CSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
Fixed a problem with raleway google font link.

Without https:// browser would look for the resource locally.